### PR TITLE
feat: Spec 02 — Three-Panel Layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tinker-scaffold",
+  "name": "tinker",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tinker-scaffold",
+      "name": "tinker",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.4",
@@ -21,6 +21,7 @@
         "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -2263,6 +2264,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,12 +4,37 @@ import { App } from './App'
 vi.mock('@/scratch/setup', () => ({
   initializeScratchVM: () => ({
     runtime: { targets: [] },
+    start: vi.fn(),
   }),
 }))
 
 describe('App', () => {
-  it('renders Tinker heading', () => {
+  it('renders all five layout areas', () => {
     render(<App />)
-    expect(screen.getByRole('heading', { name: 'Tinker' })).toBeInTheDocument()
+
+    expect(screen.getByLabelText('Green flag')).toBeInTheDocument()
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument()
+    expect(screen.getByLabelText('Block palette')).toBeInTheDocument()
+    expect(screen.getByLabelText('Script canvas')).toBeInTheDocument()
+    expect(screen.getByLabelText('Sprite stage')).toBeInTheDocument()
+    expect(screen.getByLabelText('Cosmo chat')).toBeInTheDocument()
+  })
+
+  it('renders the project name', () => {
+    render(<App />)
+    expect(screen.getByLabelText('Project name')).toBeInTheDocument()
+  })
+
+  it('renders the cosmo welcome message', () => {
+    render(<App />)
+    expect(
+      screen.getByText(/Tell me what you want to build/),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the stage canvas element', () => {
+    render(<App />)
+    expect(screen.getByLabelText('Stage canvas')).toBeInTheDocument()
+    expect(screen.getByLabelText('Stage canvas').tagName).toBe('CANVAS')
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,72 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { initializeScratchVM } from '@/scratch/setup'
+import { Toolbar } from '@/components/ui'
+import { BlockPalette } from '@/components/BlockPalette'
+import { ScriptCanvas } from '@/components/ScriptCanvas'
+import { SpriteStage } from '@/components/SpriteStage'
+import { CosmoChat } from '@/components/CosmoChat'
+import { useUIStore } from '@/store/ui'
+
+function getIsNarrow(breakpoint: number) {
+  return typeof window !== 'undefined' ? window.innerWidth < breakpoint : false
+}
+
+function useIsNarrow(breakpoint = 1024) {
+  const [isNarrow, setIsNarrow] = useState(() => getIsNarrow(breakpoint))
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+    const handler = (e: MediaQueryListEvent) => setIsNarrow(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [breakpoint])
+
+  return isNarrow
+}
 
 export function App() {
+  const isPaletteOpen = useUIStore((s) => s.isPaletteOpen)
+  const togglePalette = useUIStore((s) => s.togglePalette)
+  const isNarrow = useIsNarrow()
+
+  const showPalette = isNarrow ? isPaletteOpen : true
+
   useEffect(() => {
     const vm = initializeScratchVM()
-    console.info('scratch-vm loaded, targets:', vm.runtime.targets.length)
+    vm.start()
   }, [])
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-app-background">
-      <h1 className="font-nunito text-5xl font-bold text-app-primary">Tinker</h1>
-    </main>
+    <div className="flex h-screen w-screen flex-col overflow-hidden">
+      <Toolbar />
+
+      <div className="relative flex min-h-0 flex-1">
+        {isNarrow && (
+          <button
+            onClick={togglePalette}
+            className="absolute left-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-button bg-app-primary text-xs font-bold text-white shadow-md"
+            aria-label={isPaletteOpen ? 'Hide block palette' : 'Show block palette'}
+          >
+            ☰
+          </button>
+        )}
+
+        {showPalette && (
+          <BlockPalette
+            className={`w-palette-w shrink-0 border-r border-app-border ${
+              isNarrow
+                ? 'absolute inset-y-0 left-0 z-10 shadow-lg'
+                : ''
+            }`}
+          />
+        )}
+
+        <ScriptCanvas className="min-w-0 flex-1" />
+
+        <SpriteStage className="w-stage-w shrink-0 border-l border-app-border" />
+      </div>
+
+      <CosmoChat className="h-chatbar-h shrink-0" />
+    </div>
   )
 }

--- a/src/components/BlockPalette/BlockPalette.test.tsx
+++ b/src/components/BlockPalette/BlockPalette.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BlockPalette } from './BlockPalette'
+
+describe('BlockPalette', () => {
+  const categories = ['Motion', 'Looks', 'Sound', 'Events', 'Control', 'Sensing', 'Operators']
+
+  it('renders all block categories', () => {
+    render(<BlockPalette />)
+    for (const name of categories) {
+      expect(screen.getByText(name)).toBeInTheDocument()
+    }
+  })
+
+  it('renders category color dots', () => {
+    const { container } = render(<BlockPalette />)
+    const dots = container.querySelectorAll('span[style]')
+    expect(dots.length).toBe(categories.length)
+  })
+
+  it('highlights the selected category on click', async () => {
+    const user = userEvent.setup()
+    render(<BlockPalette />)
+
+    const motionBtn = screen.getByText('Motion').closest('button')!
+    await user.click(motionBtn)
+    expect(motionBtn).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('has section label for accessibility', () => {
+    render(<BlockPalette />)
+    expect(screen.getByLabelText('Block palette')).toBeInTheDocument()
+  })
+})

--- a/src/components/BlockPalette/BlockPalette.tsx
+++ b/src/components/BlockPalette/BlockPalette.tsx
@@ -1,7 +1,53 @@
+import { useUIStore } from '@/store/ui'
+
 export interface BlockPaletteProps {
   className?: string
 }
 
-export function BlockPalette({ className }: BlockPaletteProps) {
-  return <section className={className}>Block Palette</section>
+const CATEGORIES = [
+  { id: 'motion', name: 'Motion', color: '#4C97FF' },
+  { id: 'looks', name: 'Looks', color: '#9966FF' },
+  { id: 'sound', name: 'Sound', color: '#CF63CF' },
+  { id: 'events', name: 'Events', color: '#FFBF00' },
+  { id: 'control', name: 'Control', color: '#FFAB19' },
+  { id: 'sensing', name: 'Sensing', color: '#5CB1D6' },
+  { id: 'operators', name: 'Operators', color: '#59C059' },
+] as const
+
+export function BlockPalette({ className = '' }: BlockPaletteProps) {
+  const selectedCategory = useUIStore((s) => s.selectedCategory)
+  const setSelectedCategory = useUIStore((s) => s.setSelectedCategory)
+
+  return (
+    <section
+      className={`flex flex-col overflow-y-auto bg-app-panel ${className}`}
+      aria-label="Block palette"
+    >
+      <div className="border-b border-app-border px-3 py-2">
+        <h2 className="font-inter text-xs font-bold uppercase tracking-wide text-app-secondaryText">
+          Blocks
+        </h2>
+      </div>
+      <nav className="flex flex-col gap-0.5 p-2">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.id}
+            onClick={() => setSelectedCategory(cat.id)}
+            className={`flex items-center gap-2.5 rounded-button px-3 py-2 text-left transition-colors ${
+              selectedCategory === cat.id
+                ? 'bg-gray-100 font-semibold'
+                : 'hover:bg-gray-50'
+            }`}
+            aria-current={selectedCategory === cat.id ? 'true' : undefined}
+          >
+            <span
+              className="inline-block h-3 w-3 shrink-0 rounded-full"
+              style={{ backgroundColor: cat.color }}
+            />
+            <span className="font-inter text-sm text-app-text">{cat.name}</span>
+          </button>
+        ))}
+      </nav>
+    </section>
+  )
 }

--- a/src/components/CosmoChat/CosmoChat.test.tsx
+++ b/src/components/CosmoChat/CosmoChat.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CosmoChat } from './CosmoChat'
+
+describe('CosmoChat', () => {
+  it('renders the welcome message', () => {
+    render(<CosmoChat />)
+    expect(
+      screen.getByText(/Tell me what you want to build/),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the Cosmo avatar', () => {
+    render(<CosmoChat />)
+    expect(screen.getByLabelText('Cosmo avatar')).toBeInTheDocument()
+  })
+
+  it('renders a focusable chat input', () => {
+    render(<CosmoChat />)
+    const input = screen.getByLabelText('Chat input')
+    expect(input).toBeInTheDocument()
+    input.focus()
+    expect(input).toHaveFocus()
+  })
+
+  it('accepts text input', async () => {
+    const user = userEvent.setup()
+    render(<CosmoChat />)
+    const input = screen.getByLabelText('Chat input')
+    await user.type(input, 'make the cat jump')
+    expect(input).toHaveValue('make the cat jump')
+  })
+
+  it('clears input on send', async () => {
+    const user = userEvent.setup()
+    render(<CosmoChat />)
+    const input = screen.getByLabelText('Chat input')
+    await user.type(input, 'make the cat jump')
+    await user.keyboard('{Enter}')
+    expect(input).toHaveValue('')
+  })
+
+  it('renders a send button', () => {
+    render(<CosmoChat />)
+    expect(screen.getByLabelText('Send message')).toBeInTheDocument()
+  })
+
+  it('has section label for accessibility', () => {
+    render(<CosmoChat />)
+    expect(screen.getByLabelText('Cosmo chat')).toBeInTheDocument()
+  })
+})

--- a/src/components/CosmoChat/CosmoChat.tsx
+++ b/src/components/CosmoChat/CosmoChat.tsx
@@ -1,7 +1,59 @@
+import { useState } from 'react'
+
 export interface CosmoChatProps {
   className?: string
 }
 
-export function CosmoChat({ className }: CosmoChatProps) {
-  return <section className={className}>Cosmo Chat</section>
+const WELCOME_MESSAGE =
+  "Hi! I'm Cosmo 🤖 Tell me what you want to build and I'll help you make it!"
+
+export function CosmoChat({ className = '' }: CosmoChatProps) {
+  const [inputValue, setInputValue] = useState('')
+
+  const handleSend = () => {
+    const trimmed = inputValue.trim()
+    if (!trimmed) return
+    setInputValue('')
+  }
+
+  return (
+    <section
+      className={`flex items-start gap-3 border-t border-app-border bg-app-panel px-4 py-3 ${className}`}
+      aria-label="Cosmo chat"
+    >
+      <div
+        className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-app-cosmo text-lg font-bold text-white"
+        aria-label="Cosmo avatar"
+      >
+        C
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-2 overflow-y-auto">
+        <div className="rounded-lg bg-app-cosmo/10 px-3 py-2">
+          <p className="font-nunito text-sm text-app-text">{WELCOME_MESSAGE}</p>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSend()
+          }}
+          placeholder="Ask Cosmo something..."
+          className="w-64 rounded-input border border-app-border bg-white px-3 py-2 font-inter text-sm text-app-text outline-none placeholder:text-app-secondaryText focus:border-app-cosmo"
+          aria-label="Chat input"
+        />
+        <button
+          onClick={handleSend}
+          className="flex h-9 w-9 items-center justify-center rounded-button bg-app-cosmo text-white transition-opacity hover:opacity-80"
+          aria-label="Send message"
+        >
+          <span className="text-base">↑</span>
+        </button>
+      </div>
+    </section>
+  )
 }

--- a/src/components/ScriptCanvas/ScriptCanvas.test.tsx
+++ b/src/components/ScriptCanvas/ScriptCanvas.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { ScriptCanvas } from './ScriptCanvas'
+
+describe('ScriptCanvas', () => {
+  it('renders the empty state message', () => {
+    render(<ScriptCanvas />)
+    expect(
+      screen.getByText('Drag blocks here or ask Cosmo to help!'),
+    ).toBeInTheDocument()
+  })
+
+  it('has section label for accessibility', () => {
+    render(<ScriptCanvas />)
+    expect(screen.getByLabelText('Script canvas')).toBeInTheDocument()
+  })
+
+  it('has a dot-grid background', () => {
+    render(<ScriptCanvas />)
+    const section = screen.getByLabelText('Script canvas')
+    expect(section.style.backgroundImage).toContain('radial-gradient')
+  })
+})

--- a/src/components/ScriptCanvas/ScriptCanvas.tsx
+++ b/src/components/ScriptCanvas/ScriptCanvas.tsx
@@ -2,6 +2,23 @@ export interface ScriptCanvasProps {
   className?: string
 }
 
-export function ScriptCanvas({ className }: ScriptCanvasProps) {
-  return <section className={className}>Script Canvas</section>
+export function ScriptCanvas({ className = '' }: ScriptCanvasProps) {
+  return (
+    <section
+      className={`relative overflow-auto ${className}`}
+      aria-label="Script canvas"
+      style={{
+        backgroundColor: '#F9F7F3',
+        backgroundImage:
+          'radial-gradient(circle, #D4D2CE 1px, transparent 1px)',
+        backgroundSize: '20px 20px',
+      }}
+    >
+      <div className="flex h-full items-center justify-center">
+        <p className="select-none rounded-lg bg-white/80 px-6 py-4 text-center font-inter text-sm text-app-secondaryText shadow-sm">
+          Drag blocks here or ask Cosmo to help!
+        </p>
+      </div>
+    </section>
+  )
 }

--- a/src/components/SpriteStage/SpriteStage.test.tsx
+++ b/src/components/SpriteStage/SpriteStage.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { SpriteStage } from './SpriteStage'
+
+describe('SpriteStage', () => {
+  it('renders a canvas element', () => {
+    render(<SpriteStage />)
+    const canvas = screen.getByLabelText('Stage canvas')
+    expect(canvas).toBeInTheDocument()
+    expect(canvas.tagName).toBe('CANVAS')
+  })
+
+  it('canvas has correct dimensions', () => {
+    render(<SpriteStage />)
+    const canvas = screen.getByLabelText('Stage canvas') as HTMLCanvasElement
+    expect(canvas.width).toBe(480)
+    expect(canvas.height).toBe(360)
+  })
+
+  it('renders the sprite list placeholder', () => {
+    render(<SpriteStage />)
+    expect(screen.getByText('Sprite1')).toBeInTheDocument()
+  })
+
+  it('has section label for accessibility', () => {
+    render(<SpriteStage />)
+    expect(screen.getByLabelText('Sprite stage')).toBeInTheDocument()
+  })
+})

--- a/src/components/SpriteStage/SpriteStage.tsx
+++ b/src/components/SpriteStage/SpriteStage.tsx
@@ -1,7 +1,42 @@
+import { useRef } from 'react'
+
 export interface SpriteStageProps {
   className?: string
 }
 
-export function SpriteStage({ className }: SpriteStageProps) {
-  return <section className={className}>Sprite Stage</section>
+export function SpriteStage({ className = '' }: SpriteStageProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  return (
+    <section
+      className={`flex flex-col overflow-y-auto bg-app-panel ${className}`}
+      aria-label="Sprite stage"
+    >
+      <div className="flex items-center justify-center border-b border-app-border p-3">
+        <canvas
+          ref={canvasRef}
+          width={480}
+          height={360}
+          className="rounded border border-app-border bg-white"
+          aria-label="Stage canvas"
+        />
+      </div>
+
+      <div className="flex-1 p-3">
+        <h3 className="mb-2 font-inter text-xs font-bold uppercase tracking-wide text-app-secondaryText">
+          Sprites
+        </h3>
+        <div className="flex gap-2">
+          <div className="flex h-16 w-16 flex-col items-center justify-center rounded-lg border-2 border-app-primary bg-white p-1">
+            <div className="flex h-8 w-8 items-center justify-center rounded bg-events/20 text-lg">
+              🐱
+            </div>
+            <span className="mt-0.5 font-inter text-[10px] font-medium text-app-text">
+              Sprite1
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
 }

--- a/src/components/ui/Toolbar.test.tsx
+++ b/src/components/ui/Toolbar.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Toolbar } from './Toolbar'
+
+vi.mock('@/scratch/setup', () => ({
+  initializeScratchVM: () => ({
+    runtime: { targets: [] },
+    start: vi.fn(),
+  }),
+}))
+
+describe('Toolbar', () => {
+  it('renders green flag and stop buttons', () => {
+    render(<Toolbar />)
+    expect(screen.getByLabelText('Green flag')).toBeInTheDocument()
+    expect(screen.getByLabelText('Stop')).toBeInTheDocument()
+  })
+
+  it('renders project name', () => {
+    render(<Toolbar />)
+    expect(screen.getByLabelText('Project name')).toBeInTheDocument()
+  })
+
+  it('allows editing the project name', async () => {
+    const user = userEvent.setup()
+    render(<Toolbar />)
+
+    await user.click(screen.getByLabelText('Project name'))
+
+    const input = screen.getByLabelText('Project name')
+    expect(input.tagName).toBe('INPUT')
+
+    await user.clear(input)
+    await user.type(input, 'Cool Game')
+    await user.keyboard('{Enter}')
+
+    const nameButton = screen.getByLabelText('Project name')
+    expect(nameButton.textContent).toBe('Cool Game')
+  })
+
+  it('renders the Cosmo avatar', () => {
+    render(<Toolbar />)
+    expect(screen.getByLabelText('Cosmo avatar')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -1,0 +1,100 @@
+import { useState, useRef, useEffect } from 'react'
+import { useProjectStore } from '@/store/project'
+
+export interface ToolbarProps {
+  className?: string
+}
+
+export function Toolbar({ className = '' }: ToolbarProps) {
+  const projectName = useProjectStore((s) => s.projectName)
+  const setProjectName = useProjectStore((s) => s.setProjectName)
+  const isRunning = useProjectStore((s) => s.isRunning)
+  const greenFlag = useProjectStore((s) => s.greenFlag)
+  const stopAll = useProjectStore((s) => s.stopAll)
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(projectName)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  const handleNameSubmit = () => {
+    const trimmed = editValue.trim()
+    if (trimmed) {
+      setProjectName(trimmed)
+    } else {
+      setEditValue(projectName)
+    }
+    setIsEditing(false)
+  }
+
+  return (
+    <header
+      className={`flex h-toolbar-h items-center border-b border-app-border bg-app-panel px-4 ${className}`}
+    >
+      <div className="flex items-center gap-2">
+        <button
+          onClick={greenFlag}
+          aria-label="Green flag"
+          className="flex h-8 w-8 items-center justify-center rounded-button bg-app-success text-white transition-opacity hover:opacity-80"
+        >
+          <span className="text-sm">▶</span>
+        </button>
+        <button
+          onClick={stopAll}
+          aria-label="Stop"
+          className="flex h-8 w-8 items-center justify-center rounded-button bg-app-stop text-white transition-opacity hover:opacity-80"
+        >
+          <span className="text-sm">■</span>
+        </button>
+        {isRunning && (
+          <span className="ml-1 text-xs font-medium text-app-success">Running</span>
+        )}
+      </div>
+
+      <div className="flex flex-1 justify-center">
+        {isEditing ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={handleNameSubmit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleNameSubmit()
+              if (e.key === 'Escape') {
+                setEditValue(projectName)
+                setIsEditing(false)
+              }
+            }}
+            className="w-48 rounded-input border border-app-border bg-white px-2 py-1 text-center font-inter text-sm font-medium text-app-text outline-none focus:border-app-primary"
+            aria-label="Project name"
+          />
+        ) : (
+          <button
+            onClick={() => {
+              setEditValue(projectName)
+              setIsEditing(true)
+            }}
+            className="rounded-input px-3 py-1 font-inter text-sm font-medium text-app-text hover:bg-gray-100"
+            aria-label="Project name"
+          >
+            {projectName}
+          </button>
+        )}
+      </div>
+
+      <div
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-app-cosmo text-sm font-bold text-white"
+        aria-label="Cosmo avatar"
+      >
+        C
+      </div>
+    </header>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,1 @@
-export {}
+export { Toolbar } from './Toolbar'

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -20,7 +20,7 @@ export interface ProjectStore {
   initializeVM: (vm: VirtualMachine) => void
 }
 
-export const useProjectStore = create<ProjectStore>(() => ({
+export const useProjectStore = create<ProjectStore>((set) => ({
   targets: [],
   editingTargetId: null,
   blocks: [],
@@ -34,6 +34,6 @@ export const useProjectStore = create<ProjectStore>(() => ({
   saveProject: async () => new Blob(),
   loadProject: async () => undefined,
   loadDefaultProject: async () => undefined,
-  setProjectName: () => undefined,
+  setProjectName: (name) => set({ projectName: name }),
   initializeVM: () => undefined,
 }))

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -15,6 +15,8 @@ export interface UIStore {
   closeModal: () => void
   showWelcome: boolean
   dismissWelcome: () => void
+  isPaletteOpen: boolean
+  togglePalette: () => void
 }
 
 export const useUIStore = create<UIStore>((set) => ({
@@ -48,4 +50,6 @@ export const useUIStore = create<UIStore>((set) => ({
   closeModal: () => set({ activeModal: null }),
   showWelcome: true,
   dismissWelcome: () => set({ showWelcome: false }),
+  isPaletteOpen: true,
+  togglePalette: () => set((state) => ({ isPaletteOpen: !state.isPaletteOpen })),
 }))

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the full Tinker three-panel layout per `specs/02-layout.md`. All five areas are visible and correctly sized, with responsive behavior and placeholder content ready for subsequent specs.

Closes #2

## What's Included

### Components

| Component | Location | Description |
|---|---|---|
| **Toolbar** | `src/components/ui/Toolbar.tsx` | 48px fixed height. Green flag (▶) and stop (■) buttons, editable project name, Cosmo avatar placeholder |
| **BlockPalette** | `src/components/BlockPalette/BlockPalette.tsx` | 200px fixed width. 7 Scratch categories (Motion, Looks, Sound, Events, Control, Sensing, Operators) with color dots. Scrollable. Selectable categories |
| **ScriptCanvas** | `src/components/ScriptCanvas/ScriptCanvas.tsx` | flex-1 fills remaining space. Dot-grid background pattern. "Drag blocks here or ask Cosmo to help!" empty state |
| **SpriteStage** | `src/components/SpriteStage/SpriteStage.tsx` | 480px fixed width. 480×360 `<canvas>` element ready for scratch-render (spec 04). Sprite list placeholder with "Sprite1" |
| **CosmoChat** | `src/components/CosmoChat/CosmoChat.tsx` | 120px fixed height. Cosmo avatar, welcome message, text input with send button |

### Layout (App.tsx)

- Flexbox layout: toolbar top → three panels middle row → chat bar bottom
- Middle row takes all remaining vertical space (`min-h-0 flex-1`)
- Panels separated by 1px `#E2E0DC` borders
- Layout fills viewport exactly (no page-level scrollbars)

### Responsive Behavior

- Below 1024px: block palette collapses behind a toggle button (hamburger menu)
- Uses `window.matchMedia` for breakpoint detection
- Palette opens as overlay with shadow when toggled on narrow viewports
- Chat bar stays visible at all times

### Store Updates

- **UI store**: Added `isPaletteOpen` / `togglePalette` for responsive palette toggle
- **Project store**: Wired `setProjectName` to actually update state (was a no-op stub)

### Tests

26 tests across 6 test files covering:
- All five layout areas render correctly
- Green flag and stop buttons
- Editable project name (click to edit, Enter to save)
- Block palette categories with color dots and selection
- Script canvas dot-grid background and empty state
- Stage canvas element with correct 480×360 dimensions
- Cosmo welcome message display
- Chat input accepts text, clears on send
- Accessibility labels on all sections

## Acceptance Criteria

- [x] All five areas visible: toolbar, palette, canvas, stage, chat bar
- [x] Panels correctly sized per design-system.md specs
- [x] Layout fills the viewport exactly (no page-level scrollbars)
- [x] Panels scroll internally when content overflows
- [x] Green flag and stop buttons render in the toolbar
- [x] Project name is editable in the toolbar
- [x] Chat input field is focusable and accepts text
- [x] Cosmo welcome message displays on load
- [x] Resizing the window adjusts the canvas panel (flex-1 behavior)
- [x] Below 1024px, palette collapses behind a toggle
- [x] The stage panel has a `<canvas>` element ready for scratch-render
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27cddc3a-7d9f-4b63-909b-d1e767689d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27cddc3a-7d9f-4b63-909b-d1e767689d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

